### PR TITLE
Update __init__.py to fix an error when build the soxr package

### DIFF
--- a/src/soxr/__init__.py
+++ b/src/soxr/__init__.py
@@ -3,6 +3,8 @@
 # Python-SoXR is a Python wrapper of libsoxr.
 # https://github.com/dofuuz/python-soxr
 
+from .version import version as __version__
+
 import warnings
 
 import numpy as np
@@ -11,8 +13,6 @@ from .cysoxr import CySoxr
 from .cysoxr import cysoxr_divide_proc
 from .cysoxr import cysoxr_oneshot
 from .cysoxr import QQ, LQ, MQ, HQ, VHQ
-
-from .version import version as __version__
 
 
 # libsoxr locates memory per each channel.


### PR DESCRIPTION
move 'from .version import version as __version__' to first line.
to fix the  "AttributeError: soxr has no attribute __version__".

Successfully installed … soxr-0.3.5 librosa-0.10.0.post2 pooch-1.6.0 soundfile-0.12.1 …
after apply of this commit.


Error log:
~/downloads/soxr-0.3.5 $ ls                                                             
BUILDING.md   LICENSE.txt  PKG-INFO   docs     pyproject.toml  setup.py  tests
COPYING.LGPL  MANIFEST.in  README.md  libsoxr  setup.cfg       src
~/downloads/soxr-0.3.5 $ python setup.py build                                          /data/data/com.termux/files/usr/lib/python3.11/site-packages/pythran/tables.py:4555: FutureWarning: In the future `np.bytes` will be defined as the corresponding NumPy scalar.
  obj = getattr(themodule, elem)
Traceback (most recent call last):
  File "/data/data/com.termux/files/usr/lib/python3.11/site-packages/setuptools/config/expand.py", line 81, in __getattr__
    return next(
           ^^^^^
StopIteration

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/data/data/com.termux/files/usr/lib/python3.11/site-packages/setuptools/config/expand.py", line 191, in read_attr
    return getattr(StaticModule(module_name, spec), attr_name)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/data/com.termux/files/usr/lib/python3.11/site-packages/setuptools/config/expand.py", line 87, in __getattr__
    raise AttributeError(f"{self.name} has no attribute {attr}") from e
AttributeError: soxr has no attribute __version__

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/storage/emulated/0/Download/soxr-0.3.5/setup.py", line 98, in <module>
    setup(
  File "/data/data/com.termux/files/usr/lib/python3.11/site-packages/setuptools/__init__.py", line 107, in setup
    return distutils.core.setup(**attrs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/data/com.termux/files/usr/lib/python3.11/site-packages/setuptools/_distutils/core.py", line 159, in setup
    dist.parse_config_files()                                                          
  File "/data/data/com.termux/files/usr/lib/python3.11/site-packages/setuptools/dist.py", line 904, in parse_config_files                                                           setupcfg.parse_configuration(
  File "/data/data/com.termux/files/usr/lib/python3.11/site-packages/setuptools/config/setupcfg.py", line 189, in parse_configuration
    meta.parse()                                                                       
  File "/data/data/com.termux/files/usr/lib/python3.11/site-packages/setuptools/config/setupcfg.py", line 500, in parse
    section_parser_method(section_options)
  File "/data/data/com.termux/files/usr/lib/python3.11/site-packages/setuptools/config/setupcfg.py", line 475, in parse_section                                                     self[name] = value
    ~~~~^^^^^^
  File "/data/data/com.termux/files/usr/lib/python3.11/site-packages/setuptools/config/setupcfg.py", line 293, in __setitem__                                                       parsed = self.parsers.get(option_name, lambda x: x)(value)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/data/com.termux/files/usr/lib/python3.11/site-packages/setuptools/config/setupcfg.py", line 606, in _parse_version
    return expand.version(self._parse_attr(value, self.package_dir, self.root_dir))
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/data/com.termux/files/usr/lib/python3.11/site-packages/setuptools/config/setupcfg.py", line 417, in _parse_attr                                                       return expand.read_attr(attr_desc, package_dir, root_dir)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/data/com.termux/files/usr/lib/python3.11/site-packages/setuptools/config/expand.py", line 195, in read_attr                                                           return getattr(module, attr_name)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: module ' soxr' has no attribute '__version__'
~/downloads/soxr-0.3.5 $ ls
BUILDING.md   LICENSE.txt  PKG-INFO   docs     pyproject.toml  setup.py  tests
COPYING.LGPL  MANIFEST.in  README.md  libsoxr  setup.cfg       src